### PR TITLE
refactor(interfaces): realoca IQuoteService e IEmailService para Application layer (#48)

### DIFF
--- a/src/StockQuoteAlert.Application/Interfaces/IEmailService.cs
+++ b/src/StockQuoteAlert.Application/Interfaces/IEmailService.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace StockQuoteAlert.Domain.Interfaces
+namespace StockQuoteAlert.Application.Interfaces
 {
     public interface IEmailService
     {

--- a/src/StockQuoteAlert.Application/Interfaces/IQuoteService.cs
+++ b/src/StockQuoteAlert.Application/Interfaces/IQuoteService.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace StockQuoteAlert.Domain.Interfaces
+namespace StockQuoteAlert.Application.Interfaces
 {
     public interface IQuoteService
     {

--- a/src/StockQuoteAlert.Application/Services/MonitoringService.cs
+++ b/src/StockQuoteAlert.Application/Services/MonitoringService.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Text;
 using StockQuoteAlert.Domain.Entities;
-using StockQuoteAlert.Domain.Interfaces;
 using StockQuoteAlert.Application.DTOs;
 using StockQuoteAlert.Application.Interfaces;
 using Microsoft.Extensions.Logging;

--- a/src/StockQuoteAlert.Console/Extensions/ServiceCollectionExtensions.cs
+++ b/src/StockQuoteAlert.Console/Extensions/ServiceCollectionExtensions.cs
@@ -3,7 +3,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using StockQuoteAlert.Application.Interfaces;
 using StockQuoteAlert.Application.Services;
-using StockQuoteAlert.Domain.Interfaces;
 using StockQuoteAlert.Infrastructure.ExternalServices;
 
 namespace StockQuoteAlert.Console.Extensions

--- a/src/StockQuoteAlert.Infrastructure/ExternalServices/EmailService.cs
+++ b/src/StockQuoteAlert.Infrastructure/ExternalServices/EmailService.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using System.Net.Mail;
 using System.Net;
 using System.Threading;
-using StockQuoteAlert.Domain.Interfaces;
+using StockQuoteAlert.Application.Interfaces;
 
 namespace StockQuoteAlert.Infrastructure.ExternalServices
 {

--- a/src/StockQuoteAlert.Infrastructure/ExternalServices/QuoteService.cs
+++ b/src/StockQuoteAlert.Infrastructure/ExternalServices/QuoteService.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
-using StockQuoteAlert.Domain.Interfaces;
+using StockQuoteAlert.Application.Interfaces;
 using YahooFinanceApi;
 
 namespace StockQuoteAlert.Infrastructure.ExternalServices


### PR DESCRIPTION
- Move `IQuoteService` e `IEmailService` de `Domain/Interfaces/` para `Application/Interfaces/`
- Atualiza namespaces nos arquivos movidos\n
- Corrige usings em Infrastructure, Application e Console